### PR TITLE
getScheduleInfo 프로퍼티 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noldam-utils",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "놀담 개발 통합 모듈",
   "main": "index.js",
   "scripts": {

--- a/schedule/index.js
+++ b/schedule/index.js
@@ -92,10 +92,11 @@ const getScheduleInfo = schedules => {
     hour,
     startDate, // 임시로 두 가지 경우(camelCase, underBar) 다 수용하기로
     start_date,
+    date,
     endDate,
     end_date,
   }) => {
-    const dayStart = startDate || start_date
+    const dayStart = startDate || start_date || date
     const dayEnd = endDate || end_date
     const day = moment(dayStart).day()
     let tempCount = 0


### PR DESCRIPTION
getDatesFromSchedules로 변환시킨 스케쥴의 경우 startDate 값이 아닌 date값으로 변경되어, 해당 스케쥴로 getScheduleInfo를 사용하지 못해 급하게(?) 값 하나를 더 받을 수 있도록 수정했습니다!